### PR TITLE
chore: 🐝 Update SDK - Generate 0.0.5

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,8 +5,8 @@ management:
   docVersion: 4.14.0-alpha.1752602215751-e622ff04
   speakeasyVersion: 1.581.0
   generationVersion: 2.656.5
-  releaseVersion: 0.0.4
-  configChecksum: 8557cba34d3156150d0e05f4c441b531
+  releaseVersion: 0.0.5
+  configChecksum: 05e9a841a99351fc1945469f18f32975
   repoURL: https://github.com/criblio/cribl-control-plane-sdk-typescript.git
   installationURL: https://github.com/criblio/cribl-control-plane-sdk-typescript
   published: true

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -25,7 +25,7 @@ generation:
     generateNewTests: true
     skipResponseBodyAssertions: false
 typescript:
-  version: 0.0.4
+  version: 0.0.5
   additionalDependencies:
     dependencies: {}
     devDependencies: {}

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -6,7 +6,7 @@ sources:
         sourceBlobDigest: sha256:d1075955830e88c898cc068054d7b15b4e236a54e57d9f4af38a12a41ccd331f
         tags:
             - latest
-            - speakeasy-sdk-regen-1752602714
+            - speakeasy-sdk-regen-1752608553
             - 4.14.0-alpha.1752602215751-e622ff04
 targets:
     cribl-control-plane:
@@ -15,7 +15,7 @@ targets:
         sourceRevisionDigest: sha256:e7637f459890ff511f69784f9ba9902b26e7101641049d40439daed1640ed7e0
         sourceBlobDigest: sha256:d1075955830e88c898cc068054d7b15b4e236a54e57d9f4af38a12a41ccd331f
         codeSamplesNamespace: cribl-api-reference-typescript-code-samples
-        codeSamplesRevisionDigest: sha256:548a78afd9609b94a1bb12fa1a74918a268e5da694d2b30db6134d2fa5d64e00
+        codeSamplesRevisionDigest: sha256:be7319f73e4be96fce01657cf0aa45e7cef2d33ddcbee40be92164203593c182
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.581.0

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -29,3 +29,13 @@ Based on:
 - [typescript v0.0.4] .
 ### Releases
 - [NPM v0.0.4] https://www.npmjs.com/package/cribl-control-plane/v/0.0.4 - .
+
+## 2025-07-15 19:42:18
+### Changes
+Based on:
+- OpenAPI Doc  
+- Speakeasy CLI 1.581.0 (2.656.5) https://github.com/speakeasy-api/speakeasy
+### Generated
+- [typescript v0.0.5] .
+### Releases
+- [NPM v0.0.5] https://www.npmjs.com/package/cribl-control-plane/v/0.0.5 - .

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -18,7 +18,7 @@
     },
     "..": {
       "name": "cribl-control-plane",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "bin": {
         "mcp": "bin/mcp-server.js"
       },

--- a/jsr.json
+++ b/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "cribl-control-plane",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cribl-control-plane",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cribl-control-plane",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "bin": {
         "mcp": "bin/mcp-server.js"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cribl-control-plane",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "author": "Speakeasy",
   "type": "module",
   "bin": {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -62,8 +62,8 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 export const SDK_METADATA = {
   language: "typescript",
   openapiDocVersion: "4.14.0-alpha.1752602215751-e622ff04",
-  sdkVersion: "0.0.4",
+  sdkVersion: "0.0.5",
   genVersion: "2.656.5",
   userAgent:
-    "speakeasy-sdk/typescript 0.0.4 2.656.5 4.14.0-alpha.1752602215751-e622ff04 cribl-control-plane",
+    "speakeasy-sdk/typescript 0.0.5 2.656.5 4.14.0-alpha.1752602215751-e622ff04 cribl-control-plane",
 } as const;

--- a/src/mcp-server/mcp-server.ts
+++ b/src/mcp-server/mcp-server.ts
@@ -19,7 +19,7 @@ const routes = buildRouteMap({
 export const app = buildApplication(routes, {
   name: "mcp",
   versionInfo: {
-    currentVersion: "0.0.4",
+    currentVersion: "0.0.5",
   },
 });
 

--- a/src/mcp-server/server.ts
+++ b/src/mcp-server/server.ts
@@ -26,7 +26,7 @@ export function createMCPServer(deps: {
 }) {
   const server = new McpServer({
     name: "CriblControlPlane",
-    version: "0.0.4",
+    version: "0.0.5",
   });
 
   const client = new CriblControlPlaneCore({


### PR DESCRIPTION
> [!IMPORTANT]
> Linting report available at: <https://app.speakeasy.com/org/cribl/cribl/linting-report/aba6de1f5c102f608d2a61945a1ea375>
> OpenAPI Change report available at: <https://app.speakeasy.com/org/cribl/cribl/changes-report/e9da6f1975902f7a3aeedc675b80c795>
# SDK update
Based on:
- OpenAPI Doc  
- Speakeasy CLI 1.581.0 (2.656.5) https://github.com/speakeasy-api/speakeasy
## Versioning

Version Bump Type: [patch] - 🤖 (automated)
## OpenAPI Change Summary
No specification changes

## TYPESCRIPT CHANGELOG
No relevant generator changes

