### PR TITLE
Extend .genignore to include the example package config file.

### DIFF
--- a/.genignore
+++ b/.genignore
@@ -1,3 +1,5 @@
 /examples/.env.template
 /examples/lakeDatasetsCreate.example.ts
 /examples/README.md
+/examples/package-lock.json
+/examples/package.json


### PR DESCRIPTION
Forget to include this by default :/ 
https://github.com/criblio/cribl-control-plane-sdk-typescript/pull/121