### PR TITLE
Fix duplicate language left in example-cloud-auth.ts

### DIFF
--- a/examples/example-cloud-auth.ts
+++ b/examples/example-cloud-auth.ts
@@ -1,9 +1,6 @@
 /**
  * Cribl.Cloud Authentication Example
  * 
- * This example demonstrates how to authenticate with Cribl Cloud using OAuth2
- * client credentials flow. It shows the authentication process:
- * 
  * This example demonstrates the Cribl.Cloud authentication process using 
  * OAuth2 credentials.
  * 


### PR DESCRIPTION
@michalbiesek same fix as https://github.com/criblio/cribl_control_plane_sdk_python/pull/96