### PR TITLE
Update links to product documentation in examples

### DIFF
--- a/examples/.env.template
+++ b/examples/.env.template
@@ -8,7 +8,8 @@
 
 # Cribl.Cloud configuration environment variables
 # Use only when running example against a Cribl.Cloud instance
-# To get your CLIENT_ID and CLIENT_SECRET values, follow the steps at https://docs.cribl.io/api/#criblcloud
+# To get your CLIENT_ID and CLIENT_SECRET values, follow the steps at 
+# https://docs.cribl.io/cribl-as-code/authentication/#cloud-auth
 CLIENT_ID=your-client-id
 CLIENT_SECRET=your-client-secret
 WORKSPACE_NAME=your-workspace-name

--- a/examples/example-cloud-auth.ts
+++ b/examples/example-cloud-auth.ts
@@ -12,8 +12,8 @@
  * Prerequisites: Replace the placeholder values for ORG_ID, CLIENT_ID, 
  * CLIENT_SECRET, and WORKSPACE_NAME with your Organization ID, Client ID and 
  * Secret, and Workspace name. To get your CLIENT_ID and CLIENT_SECRET values, 
- * follow the steps at https://docs.cribl.io/api/#criblcloud. Your Client ID 
- * and Secret are sensitive information and should be kept private.
+ * follow the steps at https://docs.cribl.io/cribl-as-code/authentication/#cloud-auth. 
+ * Your Client ID and Secret are sensitive information and should be kept private.
  * 
  * NOTE: This example is for Cribl.Cloud deployments only. It does not require 
  * .env file configuration.

--- a/examples/example-cloud-search-packs-lake.ts
+++ b/examples/example-cloud-search-packs-lake.ts
@@ -11,8 +11,8 @@
  * Prerequisites: Replace the placeholder values for ORG_ID, CLIENT_ID, 
  * CLIENT_SECRET, and WORKSPACE_NAME with your Organization ID, Client ID and 
  * Secret, and Workspace name. To get your CLIENT_ID and CLIENT_SECRET values, 
- * follow the steps at https://docs.cribl.io/api/#criblcloud. Your Client ID 
- * and Secret are sensitive information and should be kept private.
+ * follow the steps at https://docs.cribl.io/cribl-as-code/authentication/#cloud-auth. 
+ * Your Client ID and Secret are sensitive information and should be kept private.
  * 
  * NOTE: This example is for Cribl.Cloud deployments only. It does not require 
  * .env file configuration.

--- a/examples/example-cloud-worker-group.ts
+++ b/examples/example-cloud-worker-group.ts
@@ -19,8 +19,8 @@
  * Prerequisites: Replace the placeholder values for ORG_ID, CLIENT_ID, 
  * CLIENT_SECRET, and WORKSPACE_NAME with your Organization ID, Client ID and 
  * Secret, and Workspace name. To get your CLIENT_ID and CLIENT_SECRET values, 
- * follow the steps at https://docs.cribl.io/api/#criblcloud. Your Client ID 
- * and Secret are sensitive information and should be kept private.
+ * follow the steps at https://docs.cribl.io/cribl-as-code/authentication/#cloud-auth. 
+ * Your Client ID and Secret are sensitive information and should be kept private.
  * 
  * NOTE: This example is for Cribl.Cloud deployments only. It does not require 
  * .env file configuration.


### PR DESCRIPTION
Replaces placeholder links in the examples with updated links to MVP docs for Cribl as Code.

The links to the Cribl as Code docs will not work until https://bitbucket.org/cribl/cribl-doc/pull-requests/5830 is merged.