### PR TITLE
[HOLD for July 22 merge] DOC-5825: Replace preview text with discontinuation information in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,7 @@ In addition to the usage examples in this repository, you can adapt the [code ex
 Complementary API reference documentation is available at https://docs.cribl.io/cribl-as-code/control-plane/. Product documentation is available at https://docs.cribl.io.
 
 > [!IMPORTANT]
-> **Preview Feature**
-> The Cribl SDKs are Preview features that are still being developed. We do not recommend using them in a production environment, because the features might not be fully tested or optimized for performance, and related documentation could be incomplete.
->
-> Please continue to submit feedback through normal Cribl support channels, but assistance might be limited while the features remain in Preview.
+> Cribl has stopped active development of the Go and TypeScript SDKs. The SDKs will remain open-source, community resources on the [Cribl Community GitHub organization](https://github.com/Cribl-Community). You can continue using the Go and TypeScript SDKs and build on them, but Cribl support will be limited to critical issues only for the defined transition period. Support will end on October 1, 2026. If you prefer to stay on a supported integration, consider migrating to the [Python SDK](https://github.com/criblio/cribl_control_plane_sdk_python), [Terraform provider](https://github.com/criblio/terraform-provider-criblio), or direct [Cribl API access](https://docs.cribl.io/cribl-as-code/api/).
 
 <!-- No Summary [summary] -->
 


### PR DESCRIPTION
In the README, replaces the preview text with SDK discontinuation information, including links to the Cribl Community GitHub org and migration options.